### PR TITLE
Setting nCores < 0 tells code to use all usable codes

### DIFF
--- a/approxposterior/approx.py
+++ b/approxposterior/approx.py
@@ -6,7 +6,7 @@
 Bayesian Posterior estimation, written in pure python, leveraging
 Dan Forman-Mackey's Gaussian Process implementation, george, and DFM's
 Metropolis-Hastings MCMC implementation, emcee. We include hybrid
-implementations of both Wang & Li (2017) and Kandasamy et al. (2015). 
+implementations of both Wang & Li (2017) and Kandasamy et al. (2015).
 
 """
 
@@ -274,7 +274,8 @@ class ApproxPosterior(object):
             next point to improve GP performance.  Defaults to 5.  Increase this
             number of the point selection is not working well.
         nCores : int (optional)
-            If > 1, use multiprocessing to distribute optimization restarts
+            If > 1, use multiprocessing to distribute optimization restarts. If
+            < 0, use all usable cores
         kwargs : dict (optional)
             Keyword arguments for user-specified loglikelihood function that
             calls the forward model.

--- a/approxposterior/gpUtils.py
+++ b/approxposterior/gpUtils.py
@@ -13,6 +13,7 @@ __all__ = ["optimizeGP"]
 from . import pool
 from . import utility as util
 import numpy as np
+import os
 import george
 from scipy.optimize import minimize, basinhopping
 
@@ -142,7 +143,8 @@ def optimizeGP(gp, theta, y, seed=None, nRestarts=5, method=None, options=None,
         Initial guess for kernel hyperparameters.  If None, defaults to
         ndim values randomly sampled from a uniform distribution over [-10, 10)
     nCores : int (optional)
-        If > 1, use multiprocessing to distribute optimization restarts
+        If > 1, use multiprocessing to distribute optimization restarts. If
+        < 0, use all usable cores
 
     Returns
     -------
@@ -161,6 +163,10 @@ def optimizeGP(gp, theta, y, seed=None, nRestarts=5, method=None, options=None,
 
     # Figure out how many cores to use with InterruptiblePool
     if nCores > 1:
+        poolType = "MultiPool"
+    # Use all usable cores
+    elif nCores < 0:
+        nCores = len(os.sched_getaffinity(0))
         poolType = "MultiPool"
     else:
         poolType = "SerialPool"

--- a/approxposterior/utility.py
+++ b/approxposterior/utility.py
@@ -300,7 +300,8 @@ def minimizeObjective(fn, y, gp, sampleFn, priorFn, bounds=None, nRestarts=5,
         next point to improve GP performance.  Defaults to 5.  Increase this
         number of the point selection is not working well.
     nCores : int (optional)
-        If > 1, use multiprocessing to distribute optimization restarts
+        If > 1, use multiprocessing to distribute optimization restarts. If
+        < 0, use all usable cores
 
     Returns
     -------
@@ -318,6 +319,10 @@ def minimizeObjective(fn, y, gp, sampleFn, priorFn, bounds=None, nRestarts=5,
     # Solve for theta that maximize fn and is allowed by prior
     # Figure out how many cores to use with InterruptiblePool
     if nCores > 1:
+        poolType = "MultiPool"
+    # Use all usable cores
+    elif nCores < 0:
+        nCores = len(os.sched_getaffinity(0))
         poolType = "MultiPool"
     else:
         poolType = "SerialPool"


### PR DESCRIPTION
All usable cores are computed according to `len(os.sched_getaffinity(0))` as suggested by https://docs.python.org/3/library/multiprocessing.html#multiprocessing.cpu_count.
        