### PR TITLE
fix ndim=1 error in samplerKwargs

### DIFF
--- a/approxposterior/approx.py
+++ b/approxposterior/approx.py
@@ -24,6 +24,7 @@ import emcee
 import george
 import os
 import warnings
+import tqdm
 
 
 class ApproxPosterior(object):
@@ -649,7 +650,7 @@ class ApproxPosterior(object):
             newY = list()
 
         # Find numNewPoints new design points
-        for ii in range(numNewPoints):
+        for ii in tqdm.tqdm(range(numNewPoints)):
 
             # If alternating utility functions, switch here!
             if self.algorithm == "alternate":

--- a/approxposterior/approx.py
+++ b/approxposterior/approx.py
@@ -361,6 +361,7 @@ class ApproxPosterior(object):
         if cache:
             np.savez(str(runName) + "APFModelCache.npz",
                      theta=self.theta, y=self.y)
+            self.gpPar = list()
 
         # Set RNG seed?
         if seed is not None:
@@ -424,11 +425,10 @@ class ApproxPosterior(object):
             if timing:
                 self.trainingTime.append(time.time() - start)
 
-            # If cache, save current GP hyperparameters
             if cache:
                 np.savez(str(runName) + "APGP.npz",
-                         gpParamNames=self.gp.get_parameter_names(),
-                         gpParamValues=self.gp.get_parameter_vector())
+                    gpParamNames=self.gp.get_parameter_names(),
+                    gpParamValues=self.gpPar)
 
             # 3) GP updated: run MCMC sampler to obtain new posterior conditioned
             # on {theta_n, log(L_t*prior)}. Use emcee to obtain posterior dist.
@@ -703,6 +703,11 @@ class ApproxPosterior(object):
                     # Always need to compute the covariance matrix when we find
                     # a new theta
                     currentHype = self.gp.get_parameter_vector()
+                    if verbose:
+                        print('hyperparameters', currentHype)
+                    if cache:
+                        self.gpPar.append(currentHype)
+
                     self.gp = george.GP(kernel=self.gp.kernel, fit_mean=True,
                                         mean=self.gp.mean,
                                         white_noise=self.gp.white_noise,

--- a/approxposterior/approx.py
+++ b/approxposterior/approx.py
@@ -92,6 +92,7 @@ class ApproxPosterior(object):
             ndim = 1
         else:
             ndim = theta.shape[-1]
+        self.ndim = ndim
 
         # Make sure y, theta are valid floats
         if np.any(~np.isfinite(self.theta)) or np.any(~np.isfinite(self.y)):

--- a/approxposterior/mcmcUtils.py
+++ b/approxposterior/mcmcUtils.py
@@ -43,13 +43,13 @@ def validateMCMCKwargs(ap, samplerKwargs, mcmcKwargs, verbose=False):
     if samplerKwargs is None:
         samplerKwargs = dict()
 
-        samplerKwargs["ndim"] = ap.theta.shape[-1]
+        samplerKwargs["ndim"] = ap.ndim
         samplerKwargs["nwalkers"] = 20 * samplerKwargs["dim"]
         samplerKwargs["log_prob_fn"] = ap._gpll
     else:
         # If user set ndim, ignore it and align it with theta's dimensionality
         samplerKwargs.pop("ndim", None)
-        samplerKwargs["ndim"] = ap.theta.shape[-1]
+        samplerKwargs["ndim"] = ap.ndim
 
         # Initialize other parameters if they're not provided
         try:


### PR DESCRIPTION
It looks like `samplerKwargs["ndim"] = ap.theta.shape[-1]` in mcmcUtils.py causes an error if `ndim=1` since theta is stored as `self.theta = np.array(theta).squeeze()` in line 87 of approx.py which changes the shape of theta from (nsamples,1) to (nsamples,). So for 1D, ndim is being set to `samplerKwargs["ndim"]=nsamples`, not `samplerKwargs["ndim"]=1`. 